### PR TITLE
[GITHUB-16] Adds delete option for rotated logs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,8 +23,11 @@ services:
   - docker
 
 before_install:
-  - sudo apt-get update -qq
-  - sudo apt-get install -o Dpkg::Options::="--force-confold" --force-yes -y docker-ce
+  - tmpdaemon=$(mktemp)
+  - sudo jq '."registry-mirrors" += ["https://mirror.gcr.io"]' /etc/docker/daemon.json > $tmpdaemon
+  - sudo mv $tmpdaemon /etc/docker/daemon.json
+  - sudo systemctl daemon-reload
+  - sudo systemctl restart docker
 
 install:
   - make deps

--- a/README.md
+++ b/README.md
@@ -38,12 +38,15 @@ This role uses two tags: **build** and **configure**
 |Variable|Default|Description|
 |---|---|---|
 |sansible_logrotate_application_logs_delay_compress|yes|Whether to delay compression of rotated application logs [1]|
+|sansible_logrotate_application_logs_delete_rotated_logs|no|Whether to delete rotated application logs via postrotate [2]|
 |sansible_logrotate_application_logs_paths|[]|Out of the box config for generic application logs|
-|sansible_logrotate_application_logs_rotate_days|7|Number of days to retain logs|
+|sansible_logrotate_application_logs_rotate_days|7|Number of days to retain application logs|
+|sansible_logrotate_application_logs_rotate_size|~|Size constraint for rotating application logs|
 |sansible_logrotate_custom_configs|[]|Specify a path and a list of options to go into the config file|
 |sansible_logrotate_version|~|Version number Logrotate package|
 
 [1] https://linux.die.net/man/8/logrotate
+[2] Forcible deletes log files as rotate 0 seems to leave a single rotated log behind
 
 ## Examples
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,10 +1,12 @@
 ---
 
 sansible_logrotate_application_logs_delay_compress: yes
+sansible_logrotate_application_logs_delete_rotated_logs: no
 sansible_logrotate_application_logs_paths: []
 #   - /bin/command_one
 #   - /usr/bin/command_two
 sansible_logrotate_application_logs_rotate_days: 7
+sansible_logrotate_application_logs_rotate_size: ~
 sansible_logrotate_custom_configs: []
 #  - name: custom_log
 #    path: "/var/log/custom/*.log"

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -12,9 +12,11 @@
 
   roles:
     - role: logrotate
+      sansible_logrotate_application_logs_delete_rotated_logs: yes
+      sansible_logrotate_application_logs_rotate_size: 100K
       sansible_logrotate_application_logs_paths:
-        - /bin/test_one
-        - /usr/bin/test_two
+        - /var/log/test_one.log
+        - /var/log/test_two.log
       sansible_logrotate_custom_configs:
         - name: test_three
           path: /var/log/test_three/*.log

--- a/templates/application_logs.logrotate.d.j2
+++ b/templates/application_logs.logrotate.d.j2
@@ -1,4 +1,4 @@
-#jinja2:trim_blocks: True
+#jinja2: lstrip_blocks: True, trim_blocks: True
 ##
 # {{ ansible_managed }}
 #
@@ -6,16 +6,24 @@
 {% for path in sansible_logrotate_application_logs_paths %}
 "{{ path }}"
 {% endfor %} {
-	daily
-	missingok
-	compress
-	{% if sansible_logrotate_application_logs_delay_compress -%}
-	delaycompress
-	{% endif -%}
-	copytruncate
-	rotate {{ sansible_logrotate_application_logs_rotate_days }}
-	sharedscripts
-	postrotate
-		service rsyslog restart
-	endscript
+    daily
+    missingok
+    compress
+    {% if sansible_logrotate_application_logs_delay_compress %}
+    delaycompress
+    {% endif %}
+    copytruncate
+    rotate {{ sansible_logrotate_application_logs_rotate_days }}
+    sharedscripts
+    {% if sansible_logrotate_application_logs_rotate_size %}
+    size {{ sansible_logrotate_application_logs_rotate_size }}
+    {% endif %}
+    postrotate
+        service rsyslog restart
+    {% if sansible_logrotate_application_logs_delete_rotated_logs %}
+        {% for path in sansible_logrotate_application_logs_paths %}
+        rm -rf "{{ path }}.*"
+        {% endfor %}
+    {% endif %}
+    endscript
 }


### PR DESCRIPTION
It seems that rotate 0 still keeps a single rotated log file,
adds an option to manually remove rotated logs via postrotate.