### PR TITLE
Fix deprecated/lint warnings with ansible 2.12+

### DIFF
--- a/tasks/build.yml
+++ b/tasks/build.yml
@@ -2,5 +2,5 @@
 
 - name: Install logrotate
   become: yes
-  package:
+  ansible.builtin.package:
     name: "{{ 'logrotate=' + sansible_logrotate_version if sansible_logrotate_version is not none else 'logrotate' }}"

--- a/tasks/configure.yml
+++ b/tasks/configure.yml
@@ -2,14 +2,16 @@
 
 - name: Configure Application Logs Logrotate Config
   become: yes
-  template:
+  ansible.builtin.template:
     dest: /etc/logrotate.d/application_logs
     src: application_logs.logrotate.d.j2
+    mode: 0644
   when: sansible_logrotate_application_logs_paths != []
 
 - name: Configure Custom Logrotate Configs
   become: yes
-  template:
+  ansible.builtin.template:
     dest: "/etc/logrotate.d/{{ item.name }}"
     src: custom_logs.logrotate.d.j2
+    mode: 0644
   with_items: "{{ sansible_logrotate_custom_configs }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,11 +1,11 @@
 ---
 
 - name: Install logrotate
-  include: build.yml
+  ansible.builtin.import_tasks: build.yml
   tags:
     - build
 
 - name: Configure logrotate
-  include: configure.yml
+  ansible.builtin.import_tasks: configure.yml
   tags:
     - configure


### PR DESCRIPTION
The most annoying with ansible-playbook:

<pre>
[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead.
This feature will be removed in version 2.16.
Deprecation warnings can be disabled by setting deprecation_warnings=False in ansible.cfg.
</pre>

Then with ansible-lint:

<pre>
# ansible-lint roles/sansible.logrotate/tasks/*

WARNING  Listing 9 violation(s) that are fatal
fqcn[action-core]: Use FQCN for builtin module actions (package).
roles/sansible.logrotate/tasks/build.yml:3 Use `ansible.builtin.package` or `ansible.legacy.package` instead.

fqcn[action-core]: Use FQCN for builtin module actions (template).
roles/sansible.logrotate/tasks/configure.yml:3 Use `ansible.builtin.template` or `ansible.legacy.template` instead.

risky-file-permissions: File permissions unset or incorrect. (warning)
roles/sansible.logrotate/tasks/configure.yml:3 Task/Handler: Configure Application Logs Logrotate Config

fqcn[action-core]: Use FQCN for builtin module actions (template).
roles/sansible.logrotate/tasks/configure.yml:10 Use `ansible.builtin.template` or `ansible.legacy.template` instead.

risky-file-permissions: File permissions unset or incorrect. (warning)
roles/sansible.logrotate/tasks/configure.yml:10 Task/Handler: Configure Custom Logrotate Configs

deprecated-module: Deprecated module. include
roles/sansible.logrotate/tasks/main.yml:3 Task/Handler: Install logrotate

fqcn[action-core]: Use FQCN for builtin module actions (include).
roles/sansible.logrotate/tasks/main.yml:3 Use `ansible.builtin.include` or `ansible.legacy.include` instead.

deprecated-module: Deprecated module. include
roles/sansible.logrotate/tasks/main.yml:8 Task/Handler: Configure logrotate

fqcn[action-core]: Use FQCN for builtin module actions (include).
roles/sansible.logrotate/tasks/main.yml:8 Use `ansible.builtin.include` or `ansible.legacy.include` instead.

You can skip specific rules or tags by adding them to your configuration file:
# .config/ansible-lint.yml
warn_list:  # or 'skip_list' to silence them completely
  - deprecated-module  # Deprecated module.
  - experimental  # all rules tagged as experimental
  - fqcn[action-core]  # Use FQCN for builtin actions.

                              Rule Violation Summary
 count tag                    profile    rule associated tags
     2 deprecated-module      basic      deprecations
     2 risky-file-permissions safety     unpredictability, experimental (warning)
     5 fqcn[action-core]      production formatting
</pre>